### PR TITLE
Get Started dependency updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,14 @@
             <div class="tab-content">
                 <div role="tabpanel" class="tab-pane active" id="dependencies">
 
+                    Add jcenter as a repository, for example:
+
+                    <pre class="prettyprint">
+repositories {
+    jcenter()
+}
+                    </pre>
+
                     Add the crnk-bom to your dependency management, for example:
 
                     <pre class="prettyprint">

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@ dependencyManagement {
                     And add the following dependencies to your classpath:
 
                     <pre class="prettyprint">
-compile 'io.crnk:crnk-setup-spring-boot'
+compile 'io.crnk:crnk-setup-spring-boot2'
 compile 'io.crnk:crnk-format-plain-json'
 compile 'io.crnk:crnk-home'
 compile 'org.springframework.boot:spring-boot-starter-web'


### PR DESCRIPTION
I found I needed to do a few things differently than shown in Get Started:

- As the docs mention, I needed jcenter as a repository. Spring Initializr seems to default to Maven Central instead, so I think it's valuable to put jcenter in the Get Started
- Since Get Started was created, `crnk-setup-spring-boot` seems to have been split into `crnk-setup-spring-boot1` and `crnk-setup-spring-boot2`, so this updates Get Started to point to `crnk-setup-spring-boot2`